### PR TITLE
Technical drawings and deps increase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,12 +19,12 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 LegendDetectorDesignPlotsExt = ["RecipesBase", "Plots"]
 
 [compat]
-LegendDataManagement = "0.5.3"
+LegendDataManagement = "0.5.4"
 LinearAlgebra = "1"
 Plots = "<0.0.1, 1"
 Printf = "1"
 PropDicts = "0.2.9"
 RecipesBase = "1"
-SolidStateDetectors = "0.10.14"
+SolidStateDetectors = "0.10.16"
 Unitful = "1.11"
 julia = "1.10"


### PR DESCRIPTION
Technical drawings can now be made nicely with 
```julia
plot(ldet, technical_drawing = true, crystal_prefix = "C-", corner_rounding = :bottom)
```
Corner rounding parses outer tapers of selected taper (`:top`, `:bottom`, `:both`) as rounded corners