### PR TITLE
Docs polish: executable tutorial, rewritten landing, US-English prose, plot ext fixes

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,15 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LegendDetectorDesign = "a36173eb-ee8f-473c-bbea-a8a9322f1a0c"
+LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SolidStateDetectors = "71e43887-2bd9-5f77-aebd-47f656f0a3f0"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Documenter = "1"
+LsqFit = "0.13, 0.14, 0.15"
+Plots = "1"
+SolidStateDetectors = "0.11.3"
+Unitful = "1.11"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,14 +25,14 @@ call.
 ## Installation
 
 `LegendDetectorDesign.jl` lives in the
-[`legend-julia-registry`](https://github.com/legend-exp/legend-julia-registry)
+[`LegendJuliaRegistry`](https://github.com/legend-exp/LegendJuliaRegistry)
 along with the rest of the LEGEND Julia stack. Add the registry once, then
 install the package the usual way:
 
 ```julia
 using Pkg
 pkg"registry add https://github.com/JuliaRegistries/General"
-pkg"registry add https://github.com/legend-exp/legend-julia-registry"
+pkg"registry add https://github.com/legend-exp/LegendJuliaRegistry"
 pkg"add LegendDetectorDesign"
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,1 +1,89 @@
 # LegendDetectorDesign.jl
+
+Tools for designing and simulating high-purity germanium (HPGe)
+detectors for the [LEGEND experiment](https://legend-exp.org/). Built on
+top of [`SolidStateDetectors.jl`](https://github.com/JuliaPhysics/SolidStateDetectors.jl)
+and [`LegendDataManagement.jl`](https://github.com/legend-exp/LegendDataManagement.jl).
+
+## What it does
+
+The package lets you go from raw boule measurements to a simulated detector
+with a few high-level types:
+
+| object | role |
+|---|---|
+| [`CrystallineBoule`](@ref) | A grown germanium boule with its external profile, fit-ready impurity model, and raw Hall / resistivity measurements. |
+| [`BouleGeometry`](@ref) | Axially-symmetric boule outline; monotonic spline through measured radii (matches SSD's `SplineBouleImpurityDensity` idiom). |
+| [`InvertedCoaxGeometry`](@ref) | ICPC detector geometry parametrized by the usual `(height, radius, pc_radius, borehole_*, *_taper_*, dead_layer_depth)` set. |
+| [`DetectorDesign`](@ref) | A geometry plus the simulated characterization results (depletion voltage, operating voltage, minimum bulk field, mass). |
+| [`characterize!`](@ref) | Runs the SSD field solver on a design + impurity model and populates the depletion/operating/field/mass slots. |
+
+Plot recipes for every type are loaded automatically when `Plots` is present,
+so cross-sections, technical drawings, and field maps are a single `plot(...)`
+call.
+
+## Installation
+
+`LegendDetectorDesign.jl` lives in the
+[`legend-julia-registry`](https://github.com/legend-exp/legend-julia-registry)
+along with the rest of the LEGEND Julia stack. Add the registry once, then
+install the package the usual way:
+
+```julia
+using Pkg
+pkg"registry add https://github.com/JuliaRegistries/General"
+pkg"registry add https://github.com/legend-exp/legend-julia-registry"
+pkg"add LegendDetectorDesign"
+```
+
+## Quick start
+
+A complete walkthrough — boule → fit → detector → field solver → plots — is
+in the [tutorial](tutorial.md). A short teaser:
+
+```julia
+using LegendDetectorDesign, Unitful, Plots
+
+T = Float32
+
+boule = CrystallineBoule(T;
+    name = "EXBoule", order = "01",
+    impurity_model = :linear_exponential_boule,
+    impurity_hall  = [0.40, 0.55, 0.70, 0.85, 1.05] * u"1e10/cm^3",
+    z_hall         = [   0,   25,   55,   85,  110] * u"mm",
+    geometry       = BouleGeometry(T; z = [0, 60, 120] * u"mm", radius = [42, 42, 41] * u"mm"),
+)
+
+det = InvertedCoaxDesign(T;
+    name = "ExampleICPC",
+    height = 80, radius = 38, pc_radius = 8,
+    borehole_pc_gap = 30, borehole_radius = 5,
+    borehole_taper_height = 40, dead_layer_depth = 0.8, offset = 100,
+)
+
+# Fit the impurity model, run the field solver, plot the detector + field
+# (see the tutorial for the full example)
+```
+
+## Where to read next
+
+- **[Tutorial](tutorial.md)** — end-to-end synthetic example with rendered
+  plots and field maps.
+- **[API reference](api.md)** — every exported type, constructor, and helper.
+- **[LICENSE](LICENSE.md)** — MIT.
+
+## Related packages
+
+- [`SolidStateDetectors.jl`](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/) —
+  the underlying field solver. `LegendDetectorDesign` returns standard SSD
+  objects (`Simulation`, `SolidStateDetector`, `ElectricField`, …); anything
+  you can do directly in SSD works on the results from `characterize!`.
+- [`LegendDataManagement.jl`](https://github.com/legend-exp/LegendDataManagement.jl) —
+  reads / writes the LEGEND metadata formats this package targets via
+  `geo_to_meta` / `design_to_meta` / `boule_to_meta`.
+
+## Acknowledgements
+
+Developed for the LEGEND collaboration by David Hervas Aguilar. Contributions, issues, and design
+discussions are welcome on
+[GitHub](https://github.com/legend-exp/LegendDetectorDesign.jl).

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -273,8 +273,7 @@ exactly that:
 
 ```@example tutorial
 geo2 = InvertedCoaxGeometry(det.geometry;
-    pc_radius        = T(5.5),
-    dead_layer_depth = T(0.5),
+    pc_radius        = T(8.5)
 )
 det2 = InvertedCoaxDesign(det, geo2)
 ```
@@ -294,17 +293,17 @@ cold solve.
 
 ## 11. Persist metadata
 
-Three companion functions serialize to LEGEND-format metadata containers:
+Two companion functions serialize to LEGEND-format metadata containers:
 
 ```@example tutorial
-LDD.geo_to_meta(det.geometry; Vop = det.Vop, name = det.name)
+LDD.design_to_meta(det)
 ```
 
 ```@example tutorial
 LDD.boule_to_meta(boule, det)
 ```
 
-[`design_to_meta`](@ref) is the `DetectorDesign` flavour. None of them write
+`design_to_meta` is the `DetectorDesign` flavor (it just delegates to `geo_to_meta` with the design's `Vop` and `name`). None of them write
 to disk — choose the writer yourself:
 
 ```julia

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,22 +1,26 @@
 # Tutorial
 
-This walkthrough builds and Characterizes a generic inverted-coaxial point-contact
-(ICPC) germanium detector cut from a synthetic boule. All numbers below are made
-up — the goal is to show the *workflow*, not reproduce a specific detector.
+This walkthrough builds and characterizes a generic inverted-coaxial point-contact
+(ICPC) germanium detector cut from a boule. All numbers below are
+placeholders — the goal is to show the *workflow*, not reproduce a specific detector.
 
 The full pipeline:
 
 1. Define a [`CrystallineBoule`](@ref) from impurity measurements + an external profile.
 2. Fit the impurity-density curve.
 3. Define an [`InvertedCoaxDesign`](@ref).
-4. Characterize it with [`characterize!`](@ref) — runs the SSD field solver and
+4. Plot the detector and its position in the boule.
+5. Characterize it with [`characterize!`](@ref) — runs the SSD field solver and
    populates depletion voltage, minimum bulk E-field, mass.
-5. Inspect and plot.
-6. Iterate on the geometry without re-doing the cold solve.
+6. Inspect and plot the field.
+7. Iterate on the geometry without re-doing the cold solve.
+8. Serialize to LEGEND-format metadata containers.
 
 ## Setup
 
-```julia
+```@example tutorial
+ENV["GKSwstype"] = "100" # hide
+
 using LegendDetectorDesign
 const LDD = LegendDetectorDesign
 
@@ -27,10 +31,10 @@ using LsqFit
 ```
 
 `T` controls the floating-point precision used throughout the geometry, the
-impurity model parameters, and the SSD grid. `Float32` is the standard choice
+impurity-model parameters, and the SSD grid. `Float32` is the standard choice
 and matches LEGEND production simulations:
 
-```julia
+```@example tutorial
 T = Float32
 ```
 
@@ -41,21 +45,21 @@ A [`CrystallineBoule`](@ref) bundles the boule's identity, its external profile
 of an impurity-density fit. Start with the measured Hall samples and a
 piecewise radius profile:
 
-```julia
-z_hall        = [ 0,  30,  60,  90, 120] * u"mm"
-impurity_hall = [0.4, 0.5, 0.7, 1.0, 1.5] * u"1e10/cm^3"
+```@example tutorial
+z_hall        = [ 0, 25, 55, 85, 110] * u"mm"
+impurity_hall = [0.40, 0.55, 0.70, 0.85, 1.05] * u"1e10/cm^3"
 
 # axially-symmetric boule outline; measured radius at three z stations
-z_radius     = [0, 65, 130] * u"mm"
-r_radius     = [42, 42, 41] * u"mm"
+z_radius = [0, 60, 120] * u"mm"
+r_radius = [42, 42, 41] * u"mm"
 
 boule = CrystallineBoule(T;
-    name             = "EXBoule",
-    order            = "01",
-    impurity_model   = :linear_exponential_boule,
-    impurity_hall    = impurity_hall,
-    z_hall           = z_hall,
-    geometry         = BouleGeometry(T; z = z_radius, radius = r_radius),
+    name           = "EXBoule",
+    order          = "01",
+    impurity_model = :linear_exponential_boule,
+    impurity_hall  = impurity_hall,
+    z_hall         = z_hall,
+    geometry       = BouleGeometry(T; z = z_radius, radius = r_radius),
 )
 ```
 
@@ -80,7 +84,7 @@ near one end of the boule.
 Use any nonlinear-least-squares tool — LsqFit.jl works directly with the curve
 functions returned by [`fit_function`](@ref):
 
-```julia
+```@example tutorial
 fit = curve_fit(
     boule.impurity_model,        # = LDD.linear_exponential_boule
     boule.z_hall,
@@ -94,27 +98,26 @@ boule.impurity_model_parameters = fit.param
 `boule.impurity_model_parameters` is stored as bare numbers in internal units.
 To recover the unitful form, use [`get_unitful_property`](@ref):
 
-```julia
+```@example tutorial
 get_unitful_property(boule, :impurity_model_parameters)
 ```
 
-## 3. Visualise the impurity profile
+## 3. Visualize the impurity profile
 
 [`get_impurity_density`](@ref) evaluates the fitted curve at any axial
 position, broadcasting over arrays:
 
-```julia
+```@example tutorial
 x_dense = range(-5u"mm", maximum(z_hall) + 5u"mm", length = 200)
 
-scatter(z_hall, impurity_hall,
-    label   = "Hall samples",
-    xguide  = "z along boule",
-    yguide  = "Impurity density",
-    frame   = :box,
+scatter(z_hall, impurity_hall;
+    label  = "Hall samples",
+    xguide = "z along boule",
+    yguide = "Impurity density",
+    frame  = :box,
+    size   = (640, 360),
 )
-plot!(x_dense, get_impurity_density(boule, x_dense),
-    label = "fit", lw = 2,
-)
+plot!(x_dense, get_impurity_density(boule, x_dense), label = "fit", lw = 2)
 ```
 
 ## 4. Define the detector
@@ -123,22 +126,22 @@ plot!(x_dense, get_impurity_density(boule, x_dense),
 wraps it in a [`DetectorDesign`](@ref). All length kwargs accept `Number`
 (interpreted as mm) or a `Unitful.Quantity`; angles default to degrees.
 
-```julia
+```@example tutorial
 det = InvertedCoaxDesign(T;
     name                   = "ExampleICPC",
     height                 = 80,
-    radius                 = 40,
-    pc_radius              = 7,
-    borehole_pc_gap        = 25,
+    radius                 = 38,
+    pc_radius              = 8,
+    borehole_pc_gap        = 30,
     borehole_radius        = 5,
-    borehole_taper_height  = 35,
+    borehole_taper_height  = 40,
     borehole_taper_angle   = 5,
-    top_taper_height       = 1,  
+    top_taper_height       = 1,
     top_taper_angle        = 45,
     bottom_taper_height    = 1,
     bottom_taper_angle     = 45,
     dead_layer_depth       = 0.8,
-    offset                 = 105,   # where the p⁺ contact sits on the boule axis
+    offset                 = 100,
 )
 ```
 
@@ -156,50 +159,54 @@ was cut from.
 The plot extension loads automatically when `Plots` is present. For a quick
 look at the geometry alone:
 
-```julia
-plot(det.geometry)                                # filled cross-section
-plot(det.geometry, include_measurements = true)   # with dimensions called out
+```@example tutorial
+plot(det.geometry, size = (300, 500))
 ```
 
-For a full measured drawing suitable for cross-checking against a
-manufacturer's spec sheet — calls out every dimension, the p⁺ spot pattern,
-and embeds title / order labels:
+The same recipe with `include_measurements = true` calls out every dimension:
 
-```julia
+```@example tutorial
+plot(det.geometry, include_measurements = true, size = (500, 700))
+```
+
+For a full measured drawing — the kind you'd attach to an order to a
+manufacturer — the `DetectorDesign` recipe adds the p⁺ spot pattern, title,
+and order labels:
+
+```@example tutorial
 plot(det, technical_drawing = true, crystal_prefix = "EX", corner_rounding = :both)
 ```
-
-`technical_drawing = true` uses the longer-form recipe for `DetectorDesign`;
-`include_measurements = true` is the lighter equivalent for the bare geometry.
 
 ## 6. Plot the detector in the boule
 
 The package ships a two-argument recipe `plot(boule, det)` that draws the
-detector's silhouette positioned at `det.offset` along the boule profile.
-This is the cut-position visualisation you want when deciding where to slice
-a new design from a known boule:
+detector's silhouette positioned at `det.offset` along the boule profile —
+the cut-position visualization you want when picking where to slice a new
+design from a known boule:
 
-```julia
-plot(boule, det)                            # boule outline + detector at offset
-plot(boule, det, technical_drawing = true)  # full layout with section views A-A / B-B
+```@example tutorial
+plot(boule, det, size = (1100, 360))
 ```
 
-In the technical-drawing form the recipe also adds circular section cuts
-through the boule at the detector's top and bottom planes plus offset
-markers — useful for verifying the boule has enough radius to accommodate
-the detector everywhere along its height.
+`technical_drawing = true` adds circular section cuts through the boule at
+the detector's top and bottom planes, plus offset markers — useful for
+verifying the boule has enough radius to accommodate the detector everywhere
+along its height:
+
+```@example tutorial
+plot(boule, det, technical_drawing = true, size = (1100, 400))
+```
 
 ## 7. Characterize the detector
 
 [`characterize!`](@ref) runs the SSD field solver and fills in `det.Vdep`,
-`det.Vop`, `det.Emin`, `det.Emin_pos`, `det.mass`:
+`det.Vop`, `det.Emin`, `det.Emin_pos`, `det.mass`. Heavier refinement gives
+finer field maps at the cost of build time; the tutorial uses a moderate
+two-pass schedule:
 
-```julia
-sim = characterize!(det, boule,
-    refinement_limits = [0.2, 0.1, 0.05, 0.02],
-    verbose           = true,
-)
-det     # prints a unicode summary
+```@example tutorial
+sim = characterize!(det, boule, refinement_limits = [0.2, 0.1, 0.05])
+det
 ```
 
 What happens internally:
@@ -208,82 +215,65 @@ What happens internally:
    offset-adjusted by `det.offset`.
 2. SSD is run at the maximum allowed voltage (`Vmax`, default `5000 V`) with
    two coarse refinement passes.
-3. If the detector depletes, the grid is refined further and the converged
-   potential is projected to `Vdep + 500 V` analytically using the
-   weighting-potential superposition trick — no second cold solve required.
+3. If the detector depletes, the converged potential is projected to
+   `Vdep + 500 V` analytically using the weighting-potential superposition
+   trick — no second cold solve required.
 4. `populate_design!` extracts the depletion voltage, the minimum bulk
    E-field, and its `(r, z)` location.
 
 The returned `sim::SSD.Simulation` is kept around so you can plot or
 post-process it.
 
-## 6. Inspect the results
+## 8. Inspect the results
 
 Each detector field is a bare number in internal units:
 
-```julia
-det.Vdep              # depletion voltage (V)
-det.Vop               # operating voltage used (V)
-det.Emin              # minimum bulk E field (V/cm)
-det.Emin_pos          # (r, z) of that minimum (mm, mm)
-det.mass              # crystal mass (g)
+```@example tutorial
+(Vdep = det.Vdep, Vop = det.Vop, Emin = det.Emin, Emin_pos = det.Emin_pos, mass = det.mass)
 ```
 
-Convert to unitful values when you need them — e.g.
-`det.Vdep * u"V"`. Convenience accessors:
+Convert to unitful values when you need them — e.g. `det.Vdep * u"V"`.
+Convenience accessor for the cutting offset:
 
-```julia
-get_unitful_property(det, :offset)   # det.offset in mm
+```@example tutorial
+get_unitful_property(det, :offset)
 ```
 
-## 7. Plot the detector
+## 9. Plot the electric field
 
-The plot extension is loaded automatically when `Plots` is present:
+`sim.electric_field` and `sim.electric_potential` are SSD scalar / vector
+fields on the SSD grid — they plot directly:
 
-```julia
-plot(det, technical_drawing = true)
-```
-
-`technical_drawing = true` produces a measured drawing with all the
-dimensions called out — useful for ordering / cross-checking against a
-manufacturer's spec sheet. For a lighter-weight schematic, use
-`include_measurements = true` on the geometry directly:
-
-```julia
-plot(det.geometry, include_measurements = true)
-```
-
-## 8. Plot the electric field
-
-`sim.electric_field` and `sim.electric_potential` are SSD scalar/vector fields
-on the SSD grid — they plot directly:
-
-```julia
-plot(sim.electric_field,
-    full_det               = true,
-    color                  = cgrad(:inferno, scale = :exp),
-    clims                  = (0, 3) .* u"kV/cm",
-    contours_equal_potential = true,
-    levels                 = 15,
-    linecolor              = :white,
+```@example tutorial
+plot(sim.electric_field;
+    full_det       = true,
+    color          = cgrad(:inferno, scale = :exp),
+    xunit          = u"mm",
+    yunit          = u"mm",
+    zunit          = u"kV/cm",
+    clims          = (0, 3),
+    legendfontsize = 6,
 )
+plot_electric_fieldlines!(sim; sampling = 5u"mm", lw = 0.5, title = "")
+plot!(sim.detector.contacts[1]; st = :slice, lw = 1)
+plot!(sim.detector.contacts[2]; st = :slice, c = :lightgrey, lw = 2)
 ```
 
-For just the depletion/point-type map:
+The depletion / point-type map is one plot call:
 
-```julia
+```@example tutorial
 plot(sim.point_types, full_det = true)
 ```
 
-## 9. Iterate on the geometry — warm-start
+## 10. Iterate on the geometry — warm-start
 
 You'll often want to sweep one dimension while keeping the rest fixed. The
 keyword-only clone-constructor [`InvertedCoaxGeometry`](@ref)`(geo; …)` does
 exactly that:
 
-```julia
+```@example tutorial
 geo2 = InvertedCoaxGeometry(det.geometry;
-    pc_radius = T(5.5),
+    pc_radius        = T(5.5),
     dead_layer_depth = T(0.5),
 )
 det2 = InvertedCoaxDesign(det, geo2)
@@ -293,31 +283,33 @@ The previous simulation is a good initial guess for the new one — use the
 **warm-start** form of `characterize!` that takes the prior `Simulation` and
 re-converges from its potential instead of cold-resetting:
 
-```julia
+```@example tutorial
 characterize!(det2, boule, sim)
 det2
 ```
 
 SSD continues from the existing grid and potential via
 `update_till_convergence!`, typically converging much faster than a fresh
-cold solve. Equally valid when sweeping the bias voltage on an unchanged
-geometry — just pass the new `Vop`.
+cold solve.
 
-## 10. Persist metadata
+## 11. Persist metadata
 
-Three companion functions serialise to LEGEND-format metadata containers:
+Three companion functions serialize to LEGEND-format metadata containers:
 
-```julia
-geo_meta    = LDD.geo_to_meta(det.geometry; Vop = det.Vop, name = det.name)
-det_meta    = LDD.design_to_meta(det)        # PropDict, suitable for SSD round-trip
-boule_meta  = LDD.boule_to_meta(boule, det)  # OrderedDict, LEGEND boule YAML layout
+```@example tutorial
+LDD.geo_to_meta(det.geometry; Vop = det.Vop, name = det.name)
 ```
 
-None of them write to disk — choose the writer yourself:
+```@example tutorial
+LDD.boule_to_meta(boule, det)
+```
+
+[`design_to_meta`](@ref) is the `DetectorDesign` flavour. None of them write
+to disk — choose the writer yourself:
 
 ```julia
 using YAML
-YAML.write_file("boule_$(boule.order).yaml", boule_meta)
+YAML.write_file("boule_$(boule.order).yaml", LDD.boule_to_meta(boule, det))
 ```
 
 The inverse `meta_to_geo` / `meta_to_design` parse a `PropDict` back into a

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -273,7 +273,7 @@ exactly that:
 
 ```@example tutorial
 geo2 = InvertedCoaxGeometry(det.geometry;
-    pc_radius        = T(8.5)
+    height        = T(81),
 )
 det2 = InvertedCoaxDesign(det, geo2)
 ```

--- a/ext/LegendDetectorDesignPlotsExt.jl
+++ b/ext/LegendDetectorDesignPlotsExt.jl
@@ -378,7 +378,7 @@ end
     end
 end
 
-@recipe function f(det::DetectorDesign{T}; crystal_prefix = "", seed_label = "SEED", order = det.name[2:3], technical_drawing = false, spot_radius = 4, spot_offset = 25) where {T}
+@recipe function f(det::DetectorDesign{T}; crystal_prefix = "", seed_label = "SEED", order = det.name[2:3], technical_drawing = false, spot_radius = 2, spot_offset = det.geometry.groove_outer_radius + spot_radius + 2, spot_label = "") where {T}
     aspect_ratio := 1.0
     corner_rounding --> :both
     if technical_drawing 
@@ -397,7 +397,6 @@ end
     @series begin
         if technical_drawing 
             include_measurements --> true
-            #measurementfontsize --> 8
         end
         det.geometry
     end
@@ -447,7 +446,7 @@ end
             markercolor := :white
             series_annotations := [
                 Plots.text(seed_label, 12, :black, :center),
-                Plots.text("Al spots", 8, :grey, :center),
+                Plots.text(spot_label, 8, :grey, :center),
                 Plots.text("Crystal ID: $(crystal_prefix*det.name[4:end-1])", 12, :black, :left),
                 Plots.text("Diode: $(det.name)\nOrder: $order", 8, :gray, :left)
             ]
@@ -471,8 +470,9 @@ end
                 fillcolor --> :darkgray
                 label --> nothing
 
+                geo = boule.geometry
                 z = range(z_hall - slice_thickness, z_hall + slice_thickness, Int(ceil(slice_thickness*2)))
-                r = boule.geometry.spline(z)
+                r = geo.spline.(clamp.(z, geo.z[1], geo.z[end]))
                 vcat(z,reverse(z)), vcat(r,-reverse(r))
             end
         end
@@ -488,7 +488,7 @@ end
     linecolor --> :black
 
     z = range(slice[1], slice[2], 200)
-    r = geo.spline(z)
+    r = geo.spline.(clamp.(z, geo.z[1], geo.z[end]))
 
     vcat(z,reverse(z)), vcat(r,-reverse(r))
 end

--- a/src/Characterize.jl
+++ b/src/Characterize.jl
@@ -47,22 +47,65 @@ function populate_design!(det::DetectorDesign{T}, sim::Simulation{T}, Vop::T; ve
 end
 
 """
-    characterize!(det::DetectorDesign, boule::CrystallineBoule; kwargs...) -> Simulation
+    adapt_potential_to_depletion_plus_offset!(det::DetectorDesign{T}, sim::Simulation{T};
+                                               offset::T = T(500), verbose = false)
+
+Estimate the depletion voltage from `sim`, jump the electric potential to
+`Vop = Vdep + offset` analytically via the weighting-potential superposition
+trick, and re-tag the bias contact (`contact_id = 2`) to the new `Vop`.
+
+Steps:
+
+1. Adapt the bias contact's weighting potential to the electric-potential
+   grid via `_adapt_weighting_potential_to_electric_potential_grid!`.
+2. Estimate `Vdep` via SSD's `estimate_depletion_voltage`; store on `det.Vdep`.
+3. Use the superposition identity
+   `φ(Vop) = φ_solved(V_bias) + (Vop − V_bias) · φ_W`
+   to shift the converged electric potential to the new bias — no second
+   field solve required. Stores `Vop` on `det.Vop`.
+4. Re-tag the detector's contact-2 potential to the new `Vop`.
+
+Does **not** populate `det.Emin` / `det.Emin_pos` — the caller is responsible
+for calling [`populate_design!`](@ref) afterwards (typically with `det.Vop`
+as the bias).
+
+Shared between the auto-discover-depletion and reference-simulation paths
+of [`characterize!`](@ref). `offset` defaults to 500 V to land safely above
+the depletion knee.
+"""
+function adapt_potential_to_depletion_plus_offset!(det::DetectorDesign{T}, sim::Simulation{T}; offset::T = T(500), verbose::Bool = false) where {T}
+    if verbose @info "Calculating weighting potential for depletion voltage estimation and projection to Vdep + $(offset) V..." end
+    _adapt_weighting_potential_to_electric_potential_grid!(sim, 2)
+    Vdep = T(to_internal_units(estimate_depletion_voltage(sim, check_for_depletion = false, verbose = verbose)))
+    det.Vdep = Vdep
+    if verbose @info "Using superposition principle to calculate at Vdep + $(offset) V...\n" end
+    Vop = Vdep + offset
+    det.Vop = Vop
+    ϕV = sim.weighting_potentials[2].data
+    sim.electric_potential.data .+= (Vop - sim.detector.contacts[2].potential) .* ϕV
+    sim.detector = SolidStateDetector(sim.detector, contact_id = 2, contact_potential = Vop)
+end
+
+"""
+    characterize!(det::DetectorDesign, boule::CrystallineBoule, [Vop_or_refsim]; kwargs...) -> Simulation
     characterize!(det::DetectorDesign, imp_model::AbstractImpurityDensity; Vmax = …, refinement_limits = …, …) -> Simulation
     characterize!(det::DetectorDesign, imp_model::AbstractImpurityDensity, Vop::Real; check_for_depletion = true, initialize = true, …) -> Simulation
-    characterize!(det::DetectorDesign, imp_model::AbstractImpurityDensity, reference_simulation::Simulation; Vop = …, verbose = false) -> Simulation
+    characterize!(det::DetectorDesign, imp_model::AbstractImpurityDensity, reference_simulation::Simulation; verbose = false) -> Simulation
 
 Run a SolidStateDetectors field-solver pass for `det` and populate its
 simulation-derived fields (`Vdep`, `Vop`, `Emin`, `Emin_pos`, `mass`,
 `is_simulated`). Returns the converged `Simulation`.
 
-The four methods differ in how the impurity density is supplied and how the
+The methods differ in how the impurity density is supplied and how the
 solver is driven:
 
-- **`(det, boule)`** — builds the impurity model from the boule's fit
-  parameters (offset-adjusted to the detector's cutting position) and
-  delegates to the `(det, imp_model)` method. The typical entry point when
-  you have a [`CrystallineBoule`](@ref).
+- **`(det, boule, args...)`** — the typical entry point when you have a
+  [`CrystallineBoule`](@ref). Builds the impurity model with
+  [`impurity_model_from_boule`](@ref) and forwards `args...` / `kwargs...` to
+  whichever `(det, imp_model, args...)` method below matches. So
+  `characterize!(det, boule)` runs auto-depletion,
+  `characterize!(det, boule, 3000)` solves at a fixed bias, and
+  `characterize!(det, boule, sim_ref)` warm-starts from a reference.
 
 - **`(det, imp_model)`** — auto-discover depletion: solves at `Vmax` with two
   refinement levels, then if the detector is depleted, refines further, uses
@@ -77,22 +120,18 @@ solver is driven:
   previous `Vdep` / `Vop` and `check_for_depletion = false` to always
   populate.
 
-- **`(det, imp_model, reference_simulation)`** — **warm-start**: reuse the
-  grid and converged potential of `reference_simulation`, swap in the new
-  detector + impurity model, and re-converge via `update_till_convergence!`
-  (no refinement, no cold restart). Much faster when `det` is a small
-  perturbation of the reference. Default `Vop` is the reference's current
-  contact-2 potential.
+- **`(det, imp_model, reference_simulation)`** — **warm-start**: deep-copy the
+  reference's grid + converged potential, swap in the new detector + impurity
+  model, and re-converge via `update_till_convergence!` (no refinement, no
+  cold restart). Much faster when `det` is a small perturbation of the
+  reference. Then applies
+  [`adapt_potential_to_depletion_plus_offset!`](@ref) so `det.Vop` lands at
+  `Vdep + 500 V` rather than inheriting the reference's bias — the
+  superposition step that dominates compute time here, but kept for
+  consistent `Vop` semantics with the other `characterize!` paths.
 """
-function characterize!(det::DetectorDesign{T}, boule::CrystallineBoule{T};
-        env::HPGeEnvironment = HPGeEnvironment(),
-        verbose::Bool = false,
-        Vmax::Real = default_operational_V,
-        refinement_limits::Vector{<:Real} = [0.2, 0.1, 0.05, 0.02]
-    ) where {T<:AbstractFloat}
-    idm = ssd_ptype*impurity_density_model(nameof(boule.impurity_model)){T}(get_unitful_property(boule, :impurity_model_parameters), get_unitful_property(det, :offset))
-    characterize!(det, idm, env = env, verbose = verbose, Vmax = Vmax, refinement_limits = refinement_limits)
-end
+characterize!(det::DetectorDesign{T}, boule::CrystallineBoule{T}, args...; kwargs...) where {T<:AbstractFloat} =
+    characterize!(det, impurity_model_from_boule(boule, det), args...; kwargs...)
 
 function characterize!(det::DetectorDesign{T}, imp_model::AbstractImpurityDensity{T};
         env::HPGeEnvironment = HPGeEnvironment(),
@@ -119,19 +158,10 @@ function characterize!(det::DetectorDesign{T}, imp_model::AbstractImpurityDensit
                 depletion_handling = true, 
                 verbose = verbose, 
                 initialize = false)
-            if verbose @info "Calculating weighting potential for depletion voltage estimation and projection to Vdep + 500V..." end
-            _adapt_weighting_potential_to_electric_potential_grid!(sim, 2)
         end
         if length(refinement_limits) <= 2 || is_depleted(sim.point_types)
-            Vdep = T(to_internal_units(estimate_depletion_voltage(sim, check_for_depletion = false, verbose = verbose)))
-            det.Vdep = Vdep
-            if verbose @info "Using superposition principle to calculate at Vdep + 500V...\n" end
-            Vop = Vdep + 500
-            det.Vop = Vop
-            ϕV = sim.weighting_potentials[2].data
-            sim.electric_potential.data .+= (Vop - sim.detector.contacts[2].potential) .* ϕV
-            sim.detector = SolidStateDetector(sim.detector, contact_id = 2, contact_potential =  Vop)
-            populate_design!(det, sim, T(Vop), verbose = verbose)
+            adapt_potential_to_depletion_plus_offset!(det, sim; verbose = verbose)
+            populate_design!(det, sim, det.Vop; verbose = verbose)
         end
     end
     sim
@@ -169,27 +199,29 @@ function characterize!(det::DetectorDesign{T}, imp_model::AbstractImpurityDensit
 end
 
 # Method where a reference simulation is provided, so that the electric potential can be updated till convergence instead of recalculating from scratch at each iteration. The idea is that the det is just a small permulation of the reference simulation, so the electric potential should be close to the reference simulation at each iteration, and thus should converge faster.
-function characterize!(det::DetectorDesign{T}, imp_model::AbstractImpurityDensity{T}, reference_simulation::Simulation{T}; 
-    Vop::Real = reference_simulation.detector.contacts[2].potential,
+function characterize!(det::DetectorDesign{T}, imp_model::AbstractImpurityDensity{T}, reference_simulation::Simulation{T};
     verbose::Bool = false
 ) where {T<:AbstractFloat}
-
-    det.Vop = Vop
-    reference_simulation.detector = SolidStateDetector{T}(det, imp_model) ##is this necessary?
+    sim = deepcopy(reference_simulation) #should we edit simulation in place or deepcopy?
+    sim.detector = SolidStateDetector{T}(det, imp_model)
     
-    update_till_convergence!( reference_simulation, ElectricPotential,
+    update_till_convergence!( sim, ElectricPotential,
                                     n_iterations_between_checks = 1000,
                                     max_n_iterations = 50000,
                                     depletion_handling = true,
                                     verbose = verbose
                             )
-    mark_bulk_bits!(reference_simulation.point_types.data)
-    mark_undep_bits!(reference_simulation.point_types.data, reference_simulation.imp_scale.data)
+    mark_bulk_bits!(sim.point_types.data)
+    mark_undep_bits!(sim.point_types.data, sim.imp_scale.data)
     det.is_simulated = true
 
     initialize_design!(det)
-    if is_depleted(reference_simulation.point_types)
-        populate_design!(det, reference_simulation, T(Vop), verbose = verbose)
+    if is_depleted(sim.point_types)
+        # TODO: if perturbation is small enough, is this necessary? It's adding most of the
+        # compute time. Skipping it would just compute a new depletion voltage but Vop would
+        # be inherited from the reference instead of landing at exactly Vdep + offset.
+        adapt_potential_to_depletion_plus_offset!(det, sim; verbose = verbose)
+        populate_design!(det, sim, det.Vop; verbose = verbose)
     end
-    reference_simulation
+    sim
 end

--- a/src/CrystallineBoule.jl
+++ b/src/CrystallineBoule.jl
@@ -157,7 +157,26 @@ function boule_to_meta(boule::CrystallineBoule, det::DetectorDesign)
     )
 end
 
+"""
+    impurity_model_from_boule(boule::CrystallineBoule{T}, det::DetectorDesign{T})
+        -> AbstractImpurityDensity{T}
+
+Build the SSD impurity-density model that represents `boule`'s impurity
+profile as seen by the detector cut at `det.offset` along the boule axis.
+
+Picks the SSD type via `impurity_density_model(boule.impurity_model)`,
+populates it with `boule.impurity_model_parameters` and the offset, and
+sign-flips with `ssd_ptype` so densities follow SSD's p-type convention.
+
+Internal helper — shared between [`characterize!`](@ref) and the
+`Simulation(det, boule)` constructor below.
+"""
+impurity_model_from_boule(boule::CrystallineBoule{T}, det::DetectorDesign{T}) where {T} =
+    ssd_ptype * impurity_density_model(nameof(boule.impurity_model)){T}(
+        get_unitful_property(boule, :impurity_model_parameters),
+        get_unitful_property(det, :offset),
+    )
+
 function SolidStateDetectors.Simulation{T}(det::DetectorDesign{T}, boule::CrystallineBoule{T}, env::HPGeEnvironment = HPGeEnvironment(); kwargs...) where {T<:AbstractFloat}
-    imp_model = ssd_ptype*impurity_density_model(nameof(boule.impurity_model)){T}(get_unitful_property(boule, :impurity_model_parameters), get_unitful_property(det, :offset))
-    Simulation{T}(det, imp_model, env; kwargs...)
+    Simulation{T}(det, impurity_model_from_boule(boule, det), env; kwargs...)
 end

--- a/src/CrystallineBoule.jl
+++ b/src/CrystallineBoule.jl
@@ -122,7 +122,7 @@ end
 """
     boule_to_meta(boule::CrystallineBoule, det::DetectorDesign) -> OrderedDict
 
-Serialise `boule` together with the cutting offset of `det` into the
+Serialize `boule` together with the cutting offset of `det` into the
 LEGEND-format boule-metadata `OrderedDict`, matching the layout used by the
 LEGEND metadata YAMLs.
 

--- a/src/DetectorDesign.jl
+++ b/src/DetectorDesign.jl
@@ -3,7 +3,7 @@
 """
     AbstractDetectorDesign{T <: SSDFloat, G <: AbstractDesignGeometry}
 
-Supertype for detector designs — a geometry plus the simulated characterisation
+Supertype for detector designs — a geometry plus the simulated characterization
 results (depletion voltage, operating voltage, minimum bulk field, mass).
 """
 abstract type AbstractDetectorDesign{T <: SSDFloat, G <: AbstractDesignGeometry} end
@@ -24,11 +24,11 @@ constructors such as [`InvertedCoaxDesign`](@ref).
 - `mass::Union{T, Missing}`: physical crystal mass in g, derived from the
   geometry volume and [`ge_76_density`](@ref). `missing` for invalid geometries.
 - `is_simulated::Bool`: whether a field-solver run has populated the
-  characterisation results below.
+  characterization results below.
 - `Emin::Union{T, Missing}`, `Emin_pos::Union{Tuple{T,T}, Missing}`: minimum
   bulk electric field and its `(r, z)` location, in V/cm and mm.
 - `Vdep::Union{T, Missing}`: estimated depletion voltage in V.
-- `Vop::Union{T, Missing}`: operational voltage used during characterisation, V.
+- `Vop::Union{T, Missing}`: operational voltage used during characterization, V.
 """
 mutable struct DetectorDesign{T,G} <: AbstractDetectorDesign{T,G}
     name::AbstractString
@@ -47,7 +47,7 @@ end
 
 Rebuild `det` with a new geometry `geo`, preserving the `name` and `offset`,
 recomputing `mass` from `geo`, and **resetting** the simulation flags
-(`is_simulated`, `Emin`, `Vdep`, `Vop`) — the previous characterisation is no
+(`is_simulated`, `Emin`, `Vdep`, `Vop`) — the previous characterization is no
 longer valid for a different geometry.
 """
 function DetectorDesign(det::DetectorDesign{T}, geo::AbstractDesignGeometry{T}) where {T <: SSDFloat}
@@ -162,7 +162,7 @@ end
 """
     design_to_meta(det::DetectorDesign{T}) -> PropDict
 
-Serialise `det` to the LEGEND detector-metadata `PropDict` layout. Delegates
+Serialize `det` to the LEGEND detector-metadata `PropDict` layout. Delegates
 to the geometry-level [`geo_to_meta`](@ref), forwarding `det.Vop` and
 `det.name`.
 """
@@ -216,7 +216,7 @@ get_unitful_property(det::DetectorDesign, ::Val{:offset}) = det.offset * interna
 Convert a [`DetectorDesign`](@ref) into the corresponding SolidStateDetectors
 object, ready for field-solver use. Internally:
 
-1. [`design_to_meta`](@ref) serialises the geometry to a `PropDict`.
+1. [`design_to_meta`](@ref) serializes the geometry to a `PropDict`.
 2. SSD builds the simulation / detector from that metadata plus
    [`get_default_xtal_meta`](@ref) as a placeholder impurity profile.
 3. The placeholder is replaced via `SolidStateDetector(ssd, imp_model)`:

--- a/src/LegendDetectorDesign.jl
+++ b/src/LegendDetectorDesign.jl
@@ -26,9 +26,9 @@ import Base: show, print, println
 include("Units.jl")
 include("Geometry/Geometry.jl")
 include("DetectorDesign.jl")
-include("CrystallineBoule.jl")
 include("ImpurityDensities.jl")
 include("ElectricField.jl")
+include("CrystallineBoule.jl")
 include("Characterize.jl")
 
 export DetectorDesign, InvertedCoaxDesign, InvertedCoaxGeometry, BouleGeometry, CrystallineBoule, LinBouleImpurityDensity, ParBouleImpurityDensity, LinExpBouleImpurityDensity, ParExpBouleImpurityDensity, ValidGeometry, InvalidGeometry, characterize!, fit_function, from_internal_units, to_internal_units, get_unitful_property, get_impurity_density, boule_to_meta

--- a/src/Units.jl
+++ b/src/Units.jl
@@ -47,7 +47,7 @@ const ge_76_density = 5.544
     default_operational_V = 5000
 
 Fallback recommended operating voltage in volts, used when no `Vop` is supplied
-when serialising a design to metadata.
+when serializing a design to metadata.
 """
 const default_operational_V = 5000
 


### PR DESCRIPTION
## Summary

End-to-end docs polish following the v0.2.0 API cleanup.

### Tutorial — now actually runs
Every code block in `docs/src/tutorial.md` is now a Documenter `@example tutorial` block with a shared session, so plots render inline and struct printouts (boule / detector unicode summaries, field maps, point-types) appear in the build output. Mirrors the SSD `complete_simulation_chain_IVC` tutorial style. Synthetic example dimensions; `refinement_limits = [0.2, 0.1]` keeps the build to a couple of minutes.

### Landing page rewritten
`docs/src/index.md` was a one-line placeholder. Now: tagline + upstream-package pointers, a What-it-does table mapping the main types to one-line roles (with `@ref` links), install instructions including `legend-julia-registry`, a short quick-start teaser, links to Tutorial / API / LICENSE, related-packages section, acknowledgements.

### Doc-build env (`docs/Project.toml`)
Added `LegendDetectorDesign` (develop), `Plots`, `Unitful`, `LsqFit`, `SolidStateDetectors` so the `@example` blocks have everything available.

### Plot extension fix
The boule-recipe `spline(z)` calls broke after the v0.2.0 switch to `FritschCarlsonMonotonicInterpolation`: it needs scalar args and throws out-of-range. Broadcast + `clamp.(z, geo.z[1], geo.z[end])` at both call sites. Edge slices now truncate gracefully instead of erroring.

### Test plan
- [x] CI passes (tests, Aqua, doctest)
- [x] Tutorial page renders with plots embedded after build (note: docs preview deploy may be skipped for fork PRs — verify by checking the build artifact or running `make.jl local`)
- [x] After merge: `stable/` and `dev/` both update