### PR TITLE
Plot recipe API: explicit crystal_name / order kwargs; tutorial polish

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -46,15 +46,15 @@ of an impurity-density fit. Start with the measured Hall samples and a
 piecewise radius profile:
 
 ```@example tutorial
-z_hall        = [ 0, 25, 55, 85, 110] * u"mm"
-impurity_hall = [0.40, 0.55, 0.70, 0.85, 1.05] * u"1e10/cm^3"
+z_hall        = [ 0, 5, 10, 105, 115] * u"mm"
+impurity_hall = [0.40, 0.55, 0.70, 1.35, 2.1] * u"1e10/cm^3"
 
 # axially-symmetric boule outline; measured radius at three z stations
 z_radius = [0, 60, 120] * u"mm"
 r_radius = [42, 42, 41] * u"mm"
 
 boule = CrystallineBoule(T;
-    name           = "EXBoule",
+    name           = "ExampleBoule",
     order          = "01",
     impurity_model = :linear_exponential_boule,
     impurity_hall  = impurity_hall,
@@ -174,7 +174,7 @@ manufacturer — the `DetectorDesign` recipe adds the p⁺ spot pattern, title,
 and order labels:
 
 ```@example tutorial
-plot(det, technical_drawing = true, crystal_prefix = "EX", corner_rounding = :both)
+plot(det, technical_drawing = true, crystal_name = boule.name, order = boule.order, corner_rounding = :both)
 ```
 
 ## 6. Plot the detector in the boule
@@ -205,7 +205,7 @@ finer field maps at the cost of build time; the tutorial uses a moderate
 two-pass schedule:
 
 ```@example tutorial
-sim = characterize!(det, boule, refinement_limits = [0.2, 0.1, 0.05])
+sim = characterize!(det, boule, refinement_limits = [0.2, 0.1, 0.05, 0.02])
 det
 ```
 

--- a/ext/LegendDetectorDesignPlotsExt.jl
+++ b/ext/LegendDetectorDesignPlotsExt.jl
@@ -378,7 +378,7 @@ end
     end
 end
 
-@recipe function f(det::DetectorDesign{T}; crystal_prefix = "", seed_label = "SEED", order = det.name[2:3], technical_drawing = false, spot_radius = 2, spot_offset = det.geometry.groove_outer_radius + spot_radius + 2, spot_label = "") where {T}
+@recipe function f(det::DetectorDesign{T}; crystal_name = "", seed_label = "SEED", order = "", technical_drawing = false, spot_radius = 2, spot_offset = det.geometry.groove_outer_radius + spot_radius + 2, spot_label = "") where {T}
     aspect_ratio := 1.0
     corner_rounding --> :both
     if technical_drawing 
@@ -447,7 +447,7 @@ end
             series_annotations := [
                 Plots.text(seed_label, 12, :black, :center),
                 Plots.text(spot_label, 8, :grey, :center),
-                Plots.text("Crystal ID: $(crystal_prefix*det.name[4:end-1])", 12, :black, :left),
+                Plots.text("Crystal ID: $(crystal_name)", 12, :black, :left),
                 Plots.text("Diode: $(det.name)\nOrder: $order", 8, :gray, :left)
             ]
             [0, x + spot_offset/2, 0, 0], [geo.height+16+10, y - spot_guide_offset - 3, -149, -156]


### PR DESCRIPTION
## Summary

Stacked on top of the just-merged docs PR.

### Plot recipe API change (breaking)

`ext/LegendDetectorDesignPlotsExt.jl` — `plot(det::DetectorDesign; …)`:

- `crystal_prefix = ""` → `crystal_name = ""`. The caller now passes the full crystal ID directly instead of a prefix the recipe used to concatenate to a magic substring of `det.name`.
- `order = det.name[2:3]` → `order = ""`. The recipe no longer guesses an ordering letter from positions 2-3 of the detector name; the caller passes `boule.order` (or any string).
- The crystal-ID annotation now renders `crystal_name` verbatim instead of `crystal_prefix * det.name[4:end-1]`.

**Breaking:** any caller using `plot(det; crystal_prefix = "X")` must migrate to `plot(det; crystal_name = "X<rest of id>", order = "…")`. No internal callers in this package; LEGEND notebooks need to be updated.

### Tutorial polish

`docs/src/tutorial.md`:

- Reshape the synthetic Hall samples into a more LEGEND-realistic profile with an exponential tail (`0.40, 0.55, 0.70, 1.35, 2.1` at `z = 0, 5, 10, 105, 115 mm`) — better showcase for `:linear_exponential_boule`.
- Add a fourth refinement pass to `characterize!` (`refinement_limits = [0.2, 0.1, 0.05, 0.02]`). Finer rendered field maps; CI build a bit slower.
- Use the new explicit-kwarg API in the technical-drawing plot: `crystal_name = boule.name, order = boule.order`.
- Rename the synthetic boule from `EXBoule` → `ExampleBoule`.

### Test plan

- [x] CI passes (tests, Aqua, doctest)
- [x] Tutorial page builds; the new exponential-tail fit looks reasonable in the impurity-profile plot
- [x] The technical-drawing plot renders without warnings about the renamed kwargs

### Version

This is the second breaking change merged after `0.2.0` (alongside `write_metadata` → `boule_to_meta`). If `v0.2.0` hasn't been tagged yet, fold it in; otherwise tag `v0.3.0` after merge.